### PR TITLE
Fix `org-tidy` on the latest version of `org-mode`

### DIFF
--- a/org-tidy.el
+++ b/org-tidy.el
@@ -205,8 +205,8 @@ Otherwise return nil."
   "Tidy a single property ELEMENT."
   (let* ((content (cadr element))
          (should-tidy (org-tidy-should-tidy element))
-         (beg (org-element-begin element))
-         (end (org-element-end element))
+         (beg (org-element-property :begin element))
+         (end (org-element-property :end element))
          (is-top-property (= 1 beg))
          (ovly-beg (if is-top-property 1 (1- beg)))
          (ovly-end (if is-top-property end (1- end))))

--- a/org-tidy.el
+++ b/org-tidy.el
@@ -203,12 +203,13 @@ Otherwise return nil."
 
 (defun org-tidy-properties-single (element)
   "Tidy a single property ELEMENT."
-  (-let* ((content (cadr element))
-          (should-tidy (org-tidy-should-tidy element))
-          ((&plist :begin beg :end end) content)
-          (is-top-property (= 1 beg))
-          (ovly-beg (if is-top-property 1 (1- beg)))
-          (ovly-end (if is-top-property end (1- end))))
+  (let* ((content (cadr element))
+         (should-tidy (org-tidy-should-tidy element))
+         (beg (org-element-begin element))
+         (end (org-element-end element))
+         (is-top-property (= 1 beg))
+         (ovly-beg (if is-top-property 1 (1- beg)))
+         (ovly-end (if is-top-property end (1- end))))
     (when (and should-tidy
                (not (org-tidy-overlay-exists ovly-beg ovly-end)))
       (let* ((backspace-beg (1- end))


### PR DESCRIPTION
Hi. This PR addresses #6. Apparently, Org changed the structure of its `org-element` datum at some point. With this PR, we are using the built-in `org-element-begin` and `org-element-end` to access `beg` and `end`, since `content` is now a vector instead of a plist.