### PR TITLE
Correctly handle 'invisible style in org-tidy-properties-style

### DIFF
--- a/org-tidy.el
+++ b/org-tidy.el
@@ -222,6 +222,9 @@ Otherwise return nil."
 
       (`(t keep ,_) )
 
+      (`(nil ,_ invisible)
+       (setq display 'empty push-ovly t))
+
       (`(nil ,_ inline)
        (setq display 'inline-symbol push-ovly t))
 


### PR DESCRIPTION
before this fix, `'invisible` style got regarded only for `org-tidy-top-property-style` but not for `org-tidy-properties-style`.

With this fix, also non-top properties are rendered invisible. (according to documentation on github)